### PR TITLE
(feature) prepare for MetallData integration

### DIFF
--- a/cpp/include/jsonlogic/details/ast-full.hpp
+++ b/cpp/include/jsonlogic/details/ast-full.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
-#include <boost/json.hpp>
+#include <vector>
+#include <map>
 
 #include "ast-core.hpp"
+#include <boost/json.hpp>
+
 #include "cxx-compat.hpp"
 
 #if !defined(WITH_JSONLOGIC_EXTENSIONS)

--- a/cpp/include/jsonlogic/src.hpp
+++ b/cpp/include/jsonlogic/src.hpp
@@ -1,0 +1,6 @@
+/// Header file to include the source as header-only library
+
+#pragma once
+
+#include "../../src/logic.cc"
+


### PR DESCRIPTION
made changes to allow:
* header only inclusion
* rule application on an expr in addition to any_expr
* create_logic returns a tuple (logic_rule_base), instead of a full object
* logic_rule can be constructed from the tuple returned by create_logic
* reorganized header inclusion order to check for self-containedness