### PR TITLE
(feature) add initial API support for variants

### DIFF
--- a/cpp/examples/testeval.cc
+++ b/cpp/examples/testeval.cc
@@ -1,11 +1,11 @@
-
+#include "jsonlogic/logic.hpp"
 
 #include <fstream>
 #include <iostream>
+#include <ranges>
 
 #include <boost/lexical_cast.hpp>
-
-#include "jsonlogic/logic.hpp"
+#include <boost/range/adaptor/transformed.hpp>
 
 #include <boost/json/src.hpp>
 
@@ -95,35 +95,134 @@ bool endsWith(const std::string &str, const std::string &suffix) {
           std::equal(suffix.rbegin(), suffix.rend(), str.rbegin()));
 }
 
+struct settings
+{
+  bool verbose = false;
+  bool generate_expected = false;
+  bool simple_apply = false;
+  std::string filename = {};
+};
+
+/// converts val to a value_variant
+/// \details
+///    the object \p val's lifetime MUST exceeds the returned
+///    value_variant's lifetime (in case val is a string).
+/// \throws std::runtime_error if \p val cannot be converted.
+jsonlogic::value_variant
+to_value_variant(const bjsn::value &n) {
+  jsonlogic::value_variant res;
+
+  switch (n.kind()) {
+    case bjsn::kind::string: {
+      const bjsn::string& str = n.get_string();
+      res = std::string_view(str.data(), str.size());
+      break;
+    }
+
+    case bjsn::kind::int64: {
+      res = n.get_int64();
+      break;
+    }
+
+    case bjsn::kind::uint64: {
+      res = n.get_uint64();
+      break;
+    }
+
+    case bjsn::kind::double_: {
+      res = n.get_double();
+      break;
+    }
+
+    case bjsn::kind::bool_: {
+      res = n.get_bool();
+      break;
+    }
+
+    case bjsn::kind::null: {
+      res = std::monostate{};
+      break;
+    }
+
+    default:
+      throw std::runtime_error{"cannot convert"};
+  }
+
+  assert(!res.valueless_by_exception());
+  return res;
+}
+
+
+jsonlogic::any_expr
+call_apply(settings& config, const bjsn::value& rule, const bjsn::value& data)
+{
+  using value_vector = std::vector<jsonlogic::value_variant>;
+
+  if (config.simple_apply)
+    return jsonlogic::apply(rule, data);
+
+  jsonlogic::logic_rule logic = jsonlogic::create_logic(rule);
+
+  if (!logic.has_computed_variable_names())
+  {
+    if (config.verbose)
+      std::cerr << "execute with precomputed value array." << std::endl;
+
+    try
+    {
+      auto value_maker =
+            [&data](std::string_view nm) -> jsonlogic::value_variant
+            {
+              return to_value_variant(data.as_object().at(nm));
+            };
+
+      // extract all variable values into vector
+      auto const varvalues = logic.variable_names() | boost::adaptors::transformed(value_maker);
+
+      // NOTE: data's lifetime must extend beyond the call to apply.
+      return logic.apply(value_vector(varvalues.begin(), varvalues.end()));
+    }
+    catch (...) {}
+  }
+
+  if (config.verbose)
+    std::cerr << "falling back to normal apply" << std::endl;
+
+  return logic.apply(jsonlogic::data_accessor(data));
+}
+
 int main(int argc, const char **argv) {
   constexpr bool MATCH = false;
 
-  bool verbose = false;
-  bool genExpected = false;
-
   int errorCode = 0;
+  settings config;
   std::vector<std::string> arguments(argv, argv + argc);
-  std::string filename;
   size_t argn = 1;
 
-  auto setVerbose = [&verbose]() -> void { verbose = true; };
-  auto setResult = [&genExpected]() -> void { genExpected = true; };
-  auto setFile = [&filename](const std::string &name) -> bool {
+  auto setVerbose = [&config]() -> void { config.verbose = true; };
+  auto setResult = [&config]() -> void { config.generate_expected = true; };
+  auto setSimple = [&config]() -> void { config.simple_apply = true; };
+  auto setFile = [&config](const std::string &name) -> bool {
     const bool jsonFile = endsWith(name, ".json");
 
     if (jsonFile)
-      filename = name;
+      config.filename = name;
 
     return jsonFile;
   };
 
   while (argn < arguments.size()) {
+    // clang-format off
     MATCH
-    || matchOpt0(arguments, argn, "-v", setVerbose) ||
-        matchOpt0(arguments, argn, "--verbose", setVerbose) ||
-        matchOpt0(arguments, argn, "-r", setResult) ||
-        matchOpt0(arguments, argn, "--result", setResult) ||
-        noSwitch0(arguments, argn, setFile);
+    || matchOpt0(arguments, argn, "-v", setVerbose)
+    || matchOpt0(arguments, argn, "--verbose", setVerbose)
+    || matchOpt0(arguments, argn, "-r", setResult)
+    || matchOpt0(arguments, argn, "--result", setResult)
+    || matchOpt0(arguments, argn, "-s", setSimple)
+    || matchOpt0(arguments, argn, "--simple", setSimple)
+    || noSwitch0(arguments, argn, setFile)
+    ;
+    // clang-format on
   }
 
   bjsn::value all = parseStream(std::cin);
@@ -140,19 +239,19 @@ int main(int argc, const char **argv) {
     dat.emplace_object();
 
   try {
-    jsonlogic::any_expr res = jsonlogic::apply(rule, dat);
+    jsonlogic::any_expr res = call_apply(config, rule, dat);
 
-    if (verbose)
+    if (config.verbose)
       std::cerr << res << std::endl;
 
-    if (genExpected) {
+    if (config.generate_expected) {
       std::stringstream resStream;
 
       resStream << res;
 
       allobj["expected"] = parseStream(resStream);
 
-      if (verbose)
+      if (config.verbose)
         std::cerr << allobj["expected"] << std::endl;
     } else if (hasExpected) {
       std::stringstream expStream;
@@ -162,35 +261,35 @@ int main(int argc, const char **argv) {
       resStream << res;
       errorCode = expStream.str() != resStream.str();
 
-      if (verbose && errorCode)
+      if (config.verbose && errorCode)
         std::cerr << "test failed: "
                   << "\n  exp: " << expStream.str()
                   << "\n  got: " << resStream.str() << std::endl;
     } else {
       errorCode = 1;
 
-      if (verbose)
+      if (config.verbose)
         std::cerr << "unexpected completion, result: " << res << std::endl;
     }
   } catch (const std::exception &ex) {
-    if (verbose)
+    if (config.verbose)
       std::cerr << "caught error: " << ex.what() << std::endl;
 
-    if (genExpected)
+    if (config.generate_expected)
       allobj.erase("expected");
     else if (hasExpected)
       errorCode = 1;
   } catch (...) {
-    if (verbose)
+    if (config.verbose)
       std::cerr << "caught unknown error" << std::endl;
 
     errorCode = 1;
   }
 
-  if (genExpected && (errorCode == 0))
+  if (config.generate_expected && (errorCode == 0))
     std::cout << allobj << std::endl;
 
-  if (verbose && errorCode)
+  if (config.verbose && errorCode)
     std::cerr << "errorCode: " << errorCode << std::endl;
 
   return errorCode;

--- a/cpp/tests/missing-006.json
+++ b/cpp/tests/missing-006.json
@@ -1,0 +1,1 @@
+{"rule":{"missing":[["a", "b"]]},"data":{"a":"apple", "b":null},"expected":["b"]}

--- a/cpp/tests/run-tests.sh
+++ b/cpp/tests/run-tests.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 
-TESTBIN=../examples/testeval.bin
+function run {
+  for tst in *.json; do
+    echo "testing ${TESTBIN} <$tst"
+    ${TESTBIN} <$tst
+    res=$?
+    if [[ $res -ne 0 ]] ; then
+      echo "$res"
+      exit 1
+    fi
+  done
+}
 
-for tst in *.json; do
-  echo "testing $TESTBIN <$tst"
-  $TESTBIN <$tst
-  res=$?
-  if [[ $res -ne 0 ]] ; then
-    echo "$res"
-    exit 1
-  fi
-done
+# test using apply(rule, variant_vector) 
+#      with apply(rule, data) as fallback
+TESTBIN="../examples/testeval.bin"
+run
+
+# test using always apply(rule, data)
+TESTBIN="../examples/testeval.bin -s"
+run
 
 echo "qed."
 


### PR DESCRIPTION
API changes:
* added variant_type for basic json types, to circumvent creating a data object when the data is not available as json object.
* added corresponding jsonlogic::apply function.
* add apply functions to logic_rule class to enhance oo support.
* documented exception handling for rule evaluation.
* added type variable_resolution_error that can be thrown by the data accessor to indicate that a field/variable was not present. 
  note: data accessor needs to distinguish fields with nullptr from absent fields. 
  => consider: use std::optional or an invalid any_expr to indicate a missing value instead of an exception.

Implementation
* support for value_variant (still uses boost::json::string internally)
* fix: missing and missing_some treat null-values and absent values alike. (before: null values were not reported as missing)
* the use of missing and missing_some always sets computed_variable_names on a rule.
* revise use of exception handling
* avoid boost throwing exceptions for a bad json type assumption.

Testing:
* added missing-006.json to test for existing fields with null value
* extend testeval to test both
  - apply(rule, data): with -s/--simple command line switch, and as fallback when the variant_vector fails.
  - apply(rule, variant_vector): for rules without computed variable names.