### PR TITLE
cleanup test output, add -q flag to testeval

### DIFF
--- a/cpp/tests/run-tests.sh
+++ b/cpp/tests/run-tests.sh
@@ -4,12 +4,14 @@ JSONDIR="${1}"
 
 function run {
   for tst in ${JSONDIR}/*.json; do
-    echo "testing ${TESTBIN} <$tst"
+    echo -n "testing $(basename $tst)... "
     ${TESTBIN} <$tst
     res=$?
     if [[ $res -ne 0 ]] ; then
-      echo "$res"
+      echo "error code $res"
       exit 1
+    else
+      echo "OK"
     fi
   done
 }


### PR DESCRIPTION
@ppete - I added a `-q` / `--quiet` flag to testeval (incompatible with `-v`) that produces the current-default verbosity. Without `-q` test results (got / expected) are displayed. This makes `make test` a lot nicer.