### PR TITLE
fixes contains, and adds isin

### DIFF
--- a/py/src/jsonlogic/__init__.py
+++ b/py/src/jsonlogic/__init__.py
@@ -84,6 +84,14 @@ class Expression(Operand):
         self.on = tuple(Literal(o) if not isinstance(o, Operand) else o for o in on)
 
     def _prepare(self):
+        if self.op.op == "contains":
+            o2 = self.on[0]
+            o2prep = o2._prepare() if isinstance(o2, Operand) else o2
+            o1prep = self.o1._prepare() if isinstance(self.o1, Operand) else self.o1
+            return {
+                "in": [o2prep, o1prep]
+            }
+
         return {
             str(self.op): [self.o1._prepare()]
             + list(x._prepare() if isinstance(x, Operand) else x for x in self.on)

--- a/py/src/jsonlogic/operations.py
+++ b/py/src/jsonlogic/operations.py
@@ -56,7 +56,8 @@ _jl_or = Operation("or", 2)  # single |
 #     # return Expression("in", o, self)
 
 # # to be modeled after Pandas' str.contains
-_jl_contains = Operation("in", 2)
+_jl_contains = Operation("contains", 2)
+_jl_isin = Operation("in", 2)
 _jl_regex = Operation("regex", 2)
 
 # string and array concatenation
@@ -85,6 +86,7 @@ jl_operations: dict[str, Operation] = {
     "__or__": _jl_or,
     "__invert__": _jl_not,
     "contains": _jl_contains,
+    "isin": _jl_isin,
     "regex": _jl_regex,
     "cat": _jl_cat,
 }


### PR DESCRIPTION
python contains now works properly as ".contains(haystack, needle)", and added isin for ".isin(needle, haystack)".